### PR TITLE
use context api

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,12 @@
 import React from "react";
+import { UsersProvider } from "./UserContext";
 import Users from "./Users";
 
 function App() {
-  return <Users></Users>;
+  return (
+    <UsersProvider>
+      <Users></Users>
+    </UsersProvider>
+  );
 }
-
 export default App;

--- a/src/User.js
+++ b/src/User.js
@@ -1,22 +1,19 @@
-import React from "react";
+import React, { useEffect } from "react";
 import axios from "axios";
 import { useAsync } from "react-async";
-
-async function getUser({ id }) {
-  const response = await axios.get(
-    `https://jsonplaceholder.typicode.com/users/${id}`
-  );
-  return response.data;
-}
+import { getUser, useUsersDispatch, useUsersState } from "./UserContext";
 
 function User({ id }) {
-  const {
-    data: user,
-    error,
-    isLoading,
-  } = useAsync({ promiseFn: getUser, id, watch: id });
+  const state = useUsersState();
+  const dispatch = useUsersDispatch();
 
-  if (isLoading) return <div>로딩중</div>;
+  useEffect(() => {
+    getUser(dispatch, id);
+  }, [dispatch, id]);
+
+  const { data: user, loading, error } = state.user;
+
+  if (loading) return <div>로딩중</div>;
   if (error) return <div>에러가 발생</div>;
   if (!user) return null;
 

--- a/src/UserContext.js
+++ b/src/UserContext.js
@@ -1,0 +1,126 @@
+import React, { createContext, useReducer, useContext } from "react";
+import axios from "axios";
+
+const initialState = {
+  users: {
+    loading: false,
+    data: null,
+    error: null,
+  },
+
+  user: {
+    loading: false,
+    data: null,
+    error: null,
+  },
+};
+
+const loadingState = {
+  loading: true,
+  data: null,
+  error: null,
+};
+
+const success = (data) => ({
+  loading: false,
+  data,
+  error: null,
+});
+
+const error = (error) => ({
+  loading: false,
+  data: null,
+  error: error,
+});
+
+function usersReducer(state, { type, data, error }) {
+  switch (type) {
+    case "GET_USERS":
+      return {
+        ...state,
+        users: loadingState,
+      };
+    case "GET_USERS_SUCCESS":
+      return {
+        ...state,
+        users: success(data),
+      };
+    case "GET_USERS_ERROR":
+      return {
+        ...state,
+        users: error(error),
+      };
+    case "GET_USER":
+      return {
+        ...state,
+        user: loadingState,
+      };
+    case "GET_USER_SUCCESS":
+      return {
+        ...state,
+        user: success(data),
+      };
+    case "GET_USER_ERROR":
+      return {
+        ...state,
+        user: error(error),
+      };
+    default:
+      throw new Error(`Unhanded action type :${type}`);
+  }
+}
+
+const UsersStateContext = createContext(null);
+const UsersDispatchContext = createContext(null);
+
+export function UsersProvider({ children }) {
+  const [state, dispatch] = useReducer(usersReducer, initialState);
+
+  return (
+    <UsersStateContext.Provider value={state}>
+      <UsersDispatchContext.Provider value={dispatch}>
+        {children}
+      </UsersDispatchContext.Provider>
+    </UsersStateContext.Provider>
+  );
+}
+
+export function useUsersState() {
+  const state = useContext(UsersStateContext);
+  if (!state) {
+    throw new Error("Cannot find UsersProvider");
+  }
+  return state;
+}
+
+export function useUsersDispatch() {
+  const dispatch = useContext(UsersDispatchContext);
+  if (!dispatch) {
+    throw new Error("Cannot find UsersProvider");
+  }
+  return dispatch;
+}
+
+export async function getUsers(dispatch) {
+  dispatch({ type: "GET_USERS" });
+  try {
+    const response = await axios.get(
+      "https://jsonplaceholder.typicode.com/users"
+    );
+    dispatch({ type: "GET_USERS_SUCCESS", data: response.data });
+  } catch (e) {
+    dispatch({ type: "GET_USERS_ERROR", error: e });
+  }
+}
+
+export async function getUser(dispatch, id) {
+  dispatch({ type: "GET_USER" });
+  try {
+    const response = await axios.get(
+      `https://jsonplaceholder.typicode.com/users/${id}`
+    );
+    dispatch({ type: "GET_USER_SUCCESS", data: response.data });
+  } catch (e) {
+    dispatch({ type: "GET_USER_ERROR", error: e });
+  }
+}

--- a/src/Users.js
+++ b/src/Users.js
@@ -1,27 +1,20 @@
-import React, { useState, useEffect, useReducer } from "react";
-import axios from "axios";
-import { useAsync } from "react-async";
+import React, { useState } from "react";
 import User from "./User";
-
-async function getUsers() {
-  const response = await axios.get(
-    "https://jsonplaceholder.typicode.com/users"
-  );
-  return response.data;
-}
+import { getUsers, useUsersDispatch, useUsersState } from "./UserContext";
 
 function Users() {
   const [userId, setUserId] = useState(null);
-  const {
-    data: users,
-    error,
-    isLoading,
-    reload,
-  } = useAsync({ promiseFn: getUsers });
+  const state = useUsersState();
+  const dispatch = useUsersDispatch();
 
-  if (isLoading) return <div>로딩중</div>;
+  const { data: users, loading, error } = state.users;
+  const fetchData = () => {
+    getUsers(dispatch);
+  };
+
+  if (loading) return <div>로딩중</div>;
   if (error) return <div>에러가 발생</div>;
-  if (!users) return <button onClick={reload}>불러오기</button>;
+  if (!users) return <button onClick={fetchData}>불러오기</button>;
 
   return (
     <>
@@ -36,7 +29,7 @@ function Users() {
           </li>
         ))}
       </ul>
-      <button onClick={reload}>다시 불러오기</button>
+      <button onClick={fetchData}>다시 불러오기</button>
       {userId && <User id={userId}></User>}
     </>
   );


### PR DESCRIPTION
Context api 를 사용하여 state와 dispatch 를 전역적으로 접근 할 수 있게 한다.
UserContext 라는 Reducer와 context를 제공해주는 컴포넌트를 만든다.
Reducer 는 state에서  User, Users 를 모두 관리하고, 각각의 update 에 대한 case 가 존재한다.
useUsersState와 useUsersDispatch 훅을 만들어서 바로 state와 dispatch에 접근할 수 있게 하고 getUsers, getUser 함수를 만들어서 get api를 바로 할 수 있게끔 만듬.
User, Users 컴포넌트에서 모두 state와 dispatch 를 context로 할당하고 비구조화로 user, loading, error 를 할당해준다.
User.js 에 경우 id가 변하거나 dispatch 가 변할 때마다 useEffect 를 통해 다시금 User 정보를 찾아오게끔 한다.